### PR TITLE
feat: health-check route

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const HealthResponseSchema = z.object({ ok: z.boolean() });
+
+export async function GET() {
+  const body = HealthResponseSchema.parse({ ok: true });
+  return NextResponse.json(body);
+}


### PR DESCRIPTION
## Summary
- add a simple health endpoint returning `{ ok: true }`

## Testing
- `ping -c 1 registry.npmjs.org` *(fails: Name or service not known)*
- `echo "🚫 offline – skipping npm ci"`
- `echo "skipping lint in Codex sandbox (no net)"`
- `echo "skipping tests in Codex sandbox (no net)"`
- `echo "skipping build in Codex sandbox (no net)"`