### PR TITLE
chore: enable appDir

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,5 @@
+﻿import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
Turns on the Next.js app router (src/app) so API routes are recognized.