### PR TITLE
fix(api): add pages/api/health fallback

### DIFF
--- a/pages/api/health.ts
+++ b/pages/api/health.ts
@@ -1,0 +1,8 @@
+﻿import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ ok: boolean }>
+) {
+  res.status(200).json({ ok: true });
+}


### PR DESCRIPTION
Ensure /api/health works via Pages router if appDir fails.